### PR TITLE
Added PolygonBorder shape for use in FABs, decorations, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,13 @@ dependencies:
   
 ## Usage  
   
-``` dart  
-// Import package  
+Import Package
+``` dart
 import 'package:polygon_clipper/polygon_clipper.dart';  
+```
   
+Using ClipPolygon widget
+``` dart
 ClipPolygon(  
  sides: 6, 
  borderRadius: 5.0, // Default 0.0 degrees
@@ -34,6 +37,20 @@ ClipPolygon(
  child: Container(color: Colors.black),
 );
 ```  
+
+Using PolygonBorder shape
+``` dart
+FloatingActionButton(
+  shape: PolygonBorder(
+    sides: 5,
+    borderRadius: 5.0, // Default 0.0 degrees
+    rotate: 90.0, // Default 0.0 degrees
+    border: BorderSide.none, // Default BorderSide.none
+  ),
+  onPressed: runAction,
+  child: Icon(Icons.star),
+),
+```
   
 ## Parameters  
 
@@ -42,7 +59,7 @@ ClipPolygon(
  |---|---|---|  
 | sides | int | The number of sides to draw the polygon
 | borderRadius | double | The length of the border radius in degrees.
-| rotate | double | The initial polgyon rotation in degrees.
+| rotate | double | The initial polygon rotation in degrees.
 | child | Widget | The widget that will be rendered inside the polygon.
 | boxShadows | PolygonBoxShadow[] |A list of box shadows.
 
@@ -52,6 +69,14 @@ ClipPolygon(
  |---|---|---|  
 | color | Color | The color of the box shadow.
 | elevation | double | The distance of the shadow.
+
+##### PolygonBorder
+| Param | Type | Description |
+ |---|---|---|  
+| sides | int | The number of sides to draw the polygon
+| borderRadius | double | The length of the border radius in degrees.
+| rotate | double | The initial polygon rotation in degrees.
+| border | BorderSide | The style of the border (when `PolygonBorder` is used in `Container`, etc.)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,13 @@ dependencies:
   
 ## Usage  
   
-``` dart  
-// Import package  
+Import Package
+``` dart
 import 'package:polygon_clipper/polygon_clipper.dart';  
+```
   
+Using ClipPolygon widget
+``` dart
 ClipPolygon(  
  sides: 6, 
  borderRadius: 5.0, // Default 0.0 degrees
@@ -34,6 +37,20 @@ ClipPolygon(
  child: Container(color: Colors.black),
 );
 ```  
+
+Using PolygonBorder shape
+``` dart
+FloatingActionButton(
+  shape: PolygonBorder(
+    sides: 5,
+    borderRadius: 5.0, // Default 0.0 degrees
+    rotate: 90.0, // Default 0.0 degrees
+    border: BorderSide.none, // Default BorderSide.none
+  ),
+  onPressed: runAction,
+  child: Icon(Icons.star),
+),
+```
   
 ## Parameters  
 
@@ -42,7 +59,7 @@ ClipPolygon(
  |---|---|---|  
 | sides | int | The number of sides to draw the polygon
 | borderRadius | double | The length of the border radius in degrees.
-| rotate | double | The initial polgyon rotation in degrees.
+| rotate | double | The initial polygon rotation in degrees.
 | child | Widget | The widget that will be rendered inside the polygon.
 | boxShadows | PolygonBoxShadow[] |A list of box shadows.
 
@@ -52,6 +69,14 @@ ClipPolygon(
  |---|---|---|  
 | color | Color | The color of the box shadow.
 | elevation | double | The distance of the shadow.
+
+##### PolygonBorder
+| Param | Type | Description |
+ |---|---|---|  
+| sides | int | The number of sides to draw the polygon
+| borderRadius | double | The length of the border radius in degrees.
+| rotate | double | The initial polygon rotation in degrees.
+| border | BorderSide | The style of the border (when `PolygonBorder` is used in `Container`, etc.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,10 @@ dependencies:
   
 ## Usage  
   
-Import Package
-``` dart
-import 'package:polygon_clipper/polygon_clipper.dart';  
-```
-  
 Using ClipPolygon widget
 ``` dart
+import 'package:polygon_clipper/polygon_clipper.dart';  // Import package for ClipPolygon
+
 ClipPolygon(  
  sides: 6, 
  borderRadius: 5.0, // Default 0.0 degrees
@@ -40,6 +37,8 @@ ClipPolygon(
 
 Using PolygonBorder shape
 ``` dart
+import 'package:polygon_clipper/polygon_border.dart'; // Import package for PolygonBorder
+
 FloatingActionButton(
   shape: PolygonBorder(
     sides: 5,
@@ -76,7 +75,7 @@ FloatingActionButton(
 | sides | int | The number of sides to draw the polygon
 | borderRadius | double | The length of the border radius in degrees.
 | rotate | double | The initial polygon rotation in degrees.
-| border | BorderSide | The style of the border (when `PolygonBorder` is used in `Container`, etc.)
+| border | BorderSide | The style of the border (when `PolygonBorder` is used as a decoration in `Container`, etc.)
 
 ## Contributing
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:polygon_clipper/polygon_border.dart';
 import 'package:polygon_clipper/polygon_clipper.dart';
 
 void main() => runApp(ExampleApp());
@@ -6,35 +7,87 @@ void main() => runApp(ExampleApp());
 class ExampleApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: Colors.white,
-      child: Center(
-        child: ClipPolygon(
-          child: Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                  colors: [
-                    Colors.blue[200],
-                    Colors.blue[800],
+    return MaterialApp(
+      home: Scaffold(
+
+        floatingActionButton: FloatingActionButton(
+          onPressed: () => {},
+          shape: PolygonBorder(sides: 5),
+          child: Icon(Icons.star),
+        ),
+
+        bottomNavigationBar: BottomAppBar(
+          shape: AutomaticNotchedShape(RoundedRectangleBorder(), PolygonBorder(sides: 5)),
+          color: Colors.blue.shade100,
+          notchMargin: 6.0,
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: <Widget>[
+              FlatButton(child: Text("Action 1"), onPressed: () => {},),
+              FlatButton(child: Text("Action 2"), onPressed: () => {},),
+            ],
+          ),
+        ),
+
+        floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+
+        body: Container(
+          color: Colors.white,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.max,
+            children: <Widget>[
+              ClipPolygon(
+                child: Container(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                        colors: [
+                          Colors.blue[200],
+                          Colors.blue[800],
+                        ],
+                      ),
+                    ),
+                    child: Center(
+                      child: Icon(
+                        Icons.add_a_photo,
+                        color: Colors.white,
+                        size: 150.0,
+                        textDirection: TextDirection.ltr,
+                      ),
+                    )
+                ),
+                boxShadows: [
+                  PolygonBoxShadow(color: Colors.black, elevation: 5.0),
+                ],
+                sides: 6,
+                borderRadius: 5.0,
+              ),
+
+              SizedBox(height: 32.0,),
+
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Row(
+                  children: <Widget>[
+                    Container(
+                      padding: EdgeInsets.all(18.0),
+                      margin: EdgeInsets.only(right: 16.0),
+                      decoration: ShapeDecoration(
+                          shape: PolygonBorder(
+                              sides: 7,
+                              borderRadius: 8.0,
+                              border: BorderSide(color: Colors.blue.shade800, width: 3))),
+                      child: Text('7'),
+                    ),
+                    Text('This decoration has seven sides.')
                   ],
                 ),
-              ),
-              child: Center(
-                child: Icon(
-                  Icons.add_a_photo,
-                  color: Colors.white,
-                  size: 150.0,
-                  textDirection: TextDirection.ltr,
-                ),
               )
+            ],
           ),
-          boxShadows: [
-            PolygonBoxShadow(color: Colors.black, elevation: 5.0),
-          ],
-          sides: 6,
-          borderRadius: 5.0,
         ),
       ),
     );

--- a/lib/polygon_border.dart
+++ b/lib/polygon_border.dart
@@ -1,0 +1,116 @@
+
+import 'dart:math' as math;
+import 'dart:ui';
+
+import 'package:flutter/painting.dart';
+import 'package:meta/meta.dart';
+import 'polygon_path_drawer.dart';
+
+class PolygonBorder extends ShapeBorder {
+
+  const PolygonBorder({
+    @required this.sides,
+    this.rotate = 0.0,
+    this.borderRadius = 0.0,
+    this.border = BorderSide.none,
+  }) : assert(sides != null),
+       assert(rotate != null),
+       assert(borderRadius != null),
+       assert(border != null);
+
+  final int sides;
+  final double rotate;
+  final double borderRadius;
+  final BorderSide border;
+
+  @override
+  EdgeInsetsGeometry get dimensions => EdgeInsets.all(border.width);
+
+  Path _getPath(Rect rect, double radius) {
+    var specs = PolygonPathSpecs(
+      sides: sides < 3 ? 3 : sides,
+      rotate: rotate,
+      borderRadiusAngle: borderRadius,
+    );
+
+    return PolygonPathDrawer(size: Size.fromRadius(radius), specs: specs).draw()
+        .shift(Offset(rect.center.dx - radius, rect.center.dy - radius));
+  }
+
+
+  @override
+  ShapeBorder lerpFrom(ShapeBorder a, double t) {
+    if (a is PolygonBorder && a.sides == sides) {
+      return PolygonBorder(
+        sides: sides,
+        rotate: lerpDouble(a.rotate, rotate, t),
+        borderRadius: lerpDouble(a.borderRadius, borderRadius, t),
+        border: BorderSide.lerp(a.border, border, t),
+      );
+    } else {
+      return super.lerpFrom(a, t);
+    }
+  }
+
+
+  @override
+  ShapeBorder lerpTo(ShapeBorder b, double t) {
+    if (b is PolygonBorder && b.sides == sides) {
+      return PolygonBorder(
+        sides: sides,
+        rotate: lerpDouble(rotate, b.rotate, t),
+        borderRadius: lerpDouble(borderRadius, b.borderRadius, t),
+        border: BorderSide.lerp(border, b.border, t),
+      );
+    } else {
+      return super.lerpTo(b, t);
+    }
+  }
+
+  @override
+  void paint(Canvas canvas, Rect rect, {TextDirection textDirection}) {
+    switch (border.style) {
+      case BorderStyle.none:
+        break;
+      case BorderStyle.solid:
+        var radius = (rect.shortestSide - border.width) / 2.0;
+        var path = _getPath(rect, radius);
+        canvas.drawPath(path, border.toPaint());
+        break;
+    }
+  }
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection textDirection}) {
+    return _getPath(rect, math.max(0.0, rect.shortestSide / 2.0 - border.width));
+  }
+
+  @override
+  Path getOuterPath(Rect rect, {TextDirection textDirection}) {
+    return _getPath(rect, math.max(0.0, rect.shortestSide / 2.0));
+  }
+
+  @override
+  ShapeBorder scale(double t) {
+    return PolygonBorder(sides: sides,
+        rotate : rotate,
+        borderRadius: borderRadius * t,
+        border: border.scale(t));
+  }
+
+  @override
+  int get hashCode {
+    return sides.hashCode ^ rotate.hashCode ^ borderRadius.hashCode ^ border.hashCode;
+  }
+
+  @override
+  bool operator ==(other) {
+    if (runtimeType != other.runtimeType) {
+      return false;
+    }
+
+    final PolygonBorder typedOther = other;
+    return sides == typedOther.sides && rotate == typedOther.rotate &&
+        borderRadius == typedOther.borderRadius && border == typedOther.border;
+  }
+}


### PR DESCRIPTION
Hello, I added a `PolygonBorder` class that extends `ShapeBorder`.  Internally, it uses your polygon path drawer to make the shape.

The shape can then be easily passed to `Material` components with shape such as floating action buttons, or to `ShapeDecoration` for use in widgets that draw decorations like containers.

See sample screenshot:
![Screenshot](https://user-images.githubusercontent.com/872114/53926644-31350400-40bf-11e9-9282-596f2a29346b.jpg)

API is similar to ClipPolygon, but with a border for use in decorations:
```dart
FloatingActionButton(
  shape: PolygonBorder(
    sides: 6, 
    borderRadius: 4.0, 
    rotate: 30.0,
    border: BorderSide.none,
  ),
  ...
),
```